### PR TITLE
Add procedural terrain and collider to planets

### DIFF
--- a/Assets/Scripts/ProceduralGeneration/PlanetGenerator.cs
+++ b/Assets/Scripts/ProceduralGeneration/PlanetGenerator.cs
@@ -31,6 +31,11 @@ public class PlanetGenerator : CelestialObject
         float radius = Random.Range(minPlanetRadius, maxPlanetRadius);
         GameObject planet = GenerateIcosphere(radius, planetSubdivisions);
 
+        // Apply procedural terrain and add a collider for surface interactions
+        PlanetTerrainGenerator.ApplyTerrain(planet);
+        MeshCollider meshCollider = planet.AddComponent<MeshCollider>();
+        meshCollider.sharedMesh = planet.GetComponent<MeshFilter>().mesh;
+
         // Calculate the planet's position using the Titius-Bode formula and a random angle
         float planetDistance = TitiusBodeFormula(planetIndex);
         float angle = Random.Range(0, 2 * Mathf.PI);

--- a/Assets/Scripts/ProceduralGeneration/Terrain/PlanetTerrainGenerator.cs
+++ b/Assets/Scripts/ProceduralGeneration/Terrain/PlanetTerrainGenerator.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+/// <summary>
+/// Generates procedural terrain for a planet using Perlin noise.
+/// </summary>
+public static class PlanetTerrainGenerator
+{
+    /// <summary>
+    /// Applies a Perlin noise based heightmap to the given planet mesh.
+    /// </summary>
+    /// <param name="planet">The planet GameObject whose terrain will be modified.</param>
+    /// <param name="frequency">Noise frequency controlling feature size.</param>
+    /// <param name="amplitude">Noise amplitude controlling height variation.</param>
+    public static void ApplyTerrain(GameObject planet, float frequency = 2f, float amplitude = 0.5f)
+    {
+        if (planet == null)
+        {
+            Debug.LogError("PlanetTerrainGenerator.ApplyTerrain called with null planet.");
+            return;
+        }
+
+        MeshFilter meshFilter = planet.GetComponent<MeshFilter>();
+        if (meshFilter == null)
+        {
+            Debug.LogError("PlanetTerrainGenerator requires the planet to have a MeshFilter component.");
+            return;
+        }
+
+        Mesh mesh = meshFilter.mesh;
+        Vector3[] vertices = mesh.vertices;
+        Vector3[] normals = mesh.normals;
+
+        int seed = Random.Range(0, 100000);
+
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            Vector3 normal = normals[i];
+            float noise = Mathf.PerlinNoise(normal.x * frequency + seed, normal.y * frequency + seed);
+            vertices[i] += normal * noise * amplitude;
+        }
+
+        mesh.vertices = vertices;
+        mesh.RecalculateNormals();
+        mesh.RecalculateBounds();
+
+        meshFilter.mesh = mesh;
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Perlin noise-based `PlanetTerrainGenerator` for surface variation
- Apply terrain generator and mesh collider when creating planets

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bcc7f8988321a892afca2c2bd74d