### PR TITLE
Add planet LOD controller and config asset

### DIFF
--- a/Assets/Scripts/ProceduralGeneration/PlanetGenerator.cs
+++ b/Assets/Scripts/ProceduralGeneration/PlanetGenerator.cs
@@ -31,6 +31,30 @@ public class PlanetGenerator : CelestialObject
         float radius = Random.Range(minPlanetRadius, maxPlanetRadius);
         GameObject planet = GenerateIcosphere(radius, planetSubdivisions);
 
+        // Create LOD meshes for different detail levels
+        Mesh[] lodMeshes = new Mesh[3];
+        lodMeshes[0] = planet.GetComponent<MeshFilter>().mesh;
+
+        IcoSphereGenerator generator1 = new IcoSphereGenerator(radius, Mathf.Max(0, planetSubdivisions - 1));
+        Mesh mesh1 = new Mesh();
+        mesh1.vertices = generator1.Vertices.ToArray();
+        mesh1.triangles = generator1.Triangles.ToArray();
+        mesh1.RecalculateNormals();
+        mesh1.RecalculateBounds();
+        lodMeshes[1] = mesh1;
+
+        IcoSphereGenerator generator2 = new IcoSphereGenerator(radius, Mathf.Max(0, planetSubdivisions - 2));
+        Mesh mesh2 = new Mesh();
+        mesh2.vertices = generator2.Vertices.ToArray();
+        mesh2.triangles = generator2.Triangles.ToArray();
+        mesh2.RecalculateNormals();
+        mesh2.RecalculateBounds();
+        lodMeshes[2] = mesh2;
+
+        PlanetLodConfig lodConfig = Resources.Load<PlanetLodConfig>("Settings/PlanetLodConfig");
+        PlanetLodController lodController = planet.AddComponent<PlanetLodController>();
+        lodController.Initialize(lodMeshes, lodConfig);
+
         // Calculate the planet's position using the Titius-Bode formula and a random angle
         float planetDistance = TitiusBodeFormula(planetIndex);
         float angle = Random.Range(0, 2 * Mathf.PI);

--- a/Assets/Scripts/Rendering.meta
+++ b/Assets/Scripts/Rendering.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f40d9372f2e43c498bbdca4ecdfdeac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Rendering/PlanetLodController.cs
+++ b/Assets/Scripts/Rendering/PlanetLodController.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "PlanetLodConfig", menuName = "Settings/Planet LOD Config")]
+public class PlanetLodConfig : ScriptableObject
+{
+    public float[] transitionDistances = new float[] { 25f, 50f, 100f };
+    public bool showDebugGizmos = false;
+}
+
+/// <summary>
+/// Controls level of detail for a planet by switching between meshes of different resolutions.
+/// </summary>
+[RequireComponent(typeof(MeshFilter))]
+public class PlanetLodController : MonoBehaviour
+{
+    [SerializeField]
+    private PlanetLodConfig config;
+
+    private Mesh[] lodMeshes;
+    private MeshFilter meshFilter;
+    private Transform cameraTransform;
+
+    /// <summary>
+    /// Initializes the LOD controller with meshes and configuration.
+    /// </summary>
+    /// <param name="meshes">Meshes ordered from highest to lowest detail.</param>
+    /// <param name="lodConfig">Configuration for LOD distances and gizmos.</param>
+    public void Initialize(Mesh[] meshes, PlanetLodConfig lodConfig)
+    {
+        lodMeshes = meshes;
+        config = lodConfig;
+        meshFilter = GetComponent<MeshFilter>();
+        cameraTransform = Camera.main != null ? Camera.main.transform : null;
+
+        if (lodMeshes != null && lodMeshes.Length > 0)
+        {
+            meshFilter.mesh = lodMeshes[0];
+        }
+    }
+
+    private void Update()
+    {
+        if (lodMeshes == null || lodMeshes.Length == 0 || cameraTransform == null || config == null)
+        {
+            return;
+        }
+
+        float distance = Vector3.Distance(transform.position, cameraTransform.position);
+        int level = 0;
+
+        for (int i = 0; i < config.transitionDistances.Length; i++)
+        {
+            if (distance > config.transitionDistances[i])
+            {
+                level = Mathf.Min(i + 1, lodMeshes.Length - 1);
+            }
+        }
+
+        meshFilter.mesh = lodMeshes[level];
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        if (config == null || !config.showDebugGizmos)
+        {
+            return;
+        }
+
+        Gizmos.color = Color.yellow;
+        for (int i = 0; i < config.transitionDistances.Length; i++)
+        {
+            Gizmos.DrawWireSphere(transform.position, config.transitionDistances[i]);
+        }
+    }
+}

--- a/Assets/Scripts/Rendering/PlanetLodController.cs.meta
+++ b/Assets/Scripts/Rendering/PlanetLodController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a1544b9545d4b41aef1a31c087a36b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Settings/PlanetLodConfig.asset
+++ b/Assets/Settings/PlanetLodConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a1544b9545d4b41aef1a31c087a36b4, type: 3}
+  m_Name: PlanetLodConfig
+  m_EditorClassIdentifier:
+  transitionDistances:
+  - 25
+  - 50
+  - 100
+  showDebugGizmos: 0

--- a/Assets/Settings/PlanetLodConfig.asset.meta
+++ b/Assets/Settings/PlanetLodConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f6be6c8aab046fc8fd6a94ce72f5c79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `PlanetLodController` to switch planet meshes based on distance with optional debug gizmos
- generate LOD meshes in `PlanetGenerator` and initialize controller with config
- include `PlanetLodConfig` asset for transition distance settings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bdcdb7ec832183ab80501914400e