### PR TITLE
Improve planet LOD controller and add benchmarking

### DIFF
--- a/Assets/Scripts/ProceduralGeneration/PlanetGenerator.cs
+++ b/Assets/Scripts/ProceduralGeneration/PlanetGenerator.cs
@@ -54,11 +54,17 @@ public class PlanetGenerator : CelestialObject
         PlanetLodConfig lodConfig = Resources.Load<PlanetLodConfig>("Settings/PlanetLodConfig");
         PlanetLodController lodController = planet.AddComponent<PlanetLodController>();
         lodController.Initialize(lodMeshes, lodConfig);
-        
+        if (lodConfig != null && lodConfig.enableBenchmarking)
+        {
+            PlanetLodBenchmark benchmark = planet.AddComponent<PlanetLodBenchmark>();
+            benchmark.ApplyConfig(lodConfig);
+        }
+
         // Apply procedural terrain and add a collider for surface interactions
         PlanetTerrainGenerator.ApplyTerrain(planet);
         MeshCollider meshCollider = planet.AddComponent<MeshCollider>();
-        meshCollider.sharedMesh = planet.GetComponent<MeshFilter>().mesh;
+        meshCollider.sharedMesh = lodMeshes.Length > 0 ? lodMeshes[0] : planet.GetComponent<MeshFilter>().sharedMesh;
+        lodController.SetMeshCollider(meshCollider);
 
 
         // Calculate the planet's position using the Titius-Bode formula and a random angle

--- a/Assets/Scripts/Rendering/PlanetLodBenchmark.cs
+++ b/Assets/Scripts/Rendering/PlanetLodBenchmark.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Collects simple runtime statistics about LOD evaluation to help benchmark changes.
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(PlanetLodController))]
+public class PlanetLodBenchmark : MonoBehaviour
+{
+    [SerializeField]
+    [Min(1)]
+    private int sampleCapacity = 120;
+
+    [SerializeField]
+    [Min(0f)]
+    private float logIntervalSeconds = 5f;
+
+    private PlanetLodController lodController;
+    private readonly Queue<float> samples = new Queue<float>();
+    private float accumulatedDuration;
+    private float nextLogTime;
+
+    /// <summary>
+    /// Applies configuration values derived from the shared planet LOD settings asset.
+    /// </summary>
+    /// <param name="config">Planet LOD configuration to pull benchmark settings from.</param>
+    public void ApplyConfig(PlanetLodConfig config)
+    {
+        if (config == null)
+        {
+            return;
+        }
+
+        sampleCapacity = Mathf.Max(1, config.benchmarkSampleSize);
+        logIntervalSeconds = Mathf.Max(0f, config.benchmarkLogInterval);
+        ResetLogTimer();
+    }
+
+    private void Awake()
+    {
+        lodController = GetComponent<PlanetLodController>();
+        if (lodController == null)
+        {
+            Debug.LogWarning("PlanetLodBenchmark requires a PlanetLodController component to operate.", this);
+            enabled = false;
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (lodController != null)
+        {
+            lodController.LodEvaluated += HandleLodEvaluated;
+        }
+
+        ResetLogTimer();
+    }
+
+    private void OnDisable()
+    {
+        if (lodController != null)
+        {
+            lodController.LodEvaluated -= HandleLodEvaluated;
+        }
+
+        samples.Clear();
+        accumulatedDuration = 0f;
+    }
+
+    private void Update()
+    {
+        if (logIntervalSeconds <= 0f || samples.Count == 0)
+        {
+            return;
+        }
+
+        if (Time.realtimeSinceStartup >= nextLogTime)
+        {
+            LogSamples();
+            ResetLogTimer();
+        }
+    }
+
+    /// <summary>
+    /// Forces an immediate log of current benchmark statistics.
+    /// </summary>
+    public void ForceLog()
+    {
+        if (samples.Count == 0)
+        {
+            Debug.Log($"LOD benchmark for {name}: no samples collected yet.", this);
+            return;
+        }
+
+        LogSamples();
+        ResetLogTimer();
+    }
+
+    private void HandleLodEvaluated(float durationMs)
+    {
+        samples.Enqueue(durationMs);
+        accumulatedDuration += durationMs;
+
+        while (samples.Count > sampleCapacity)
+        {
+            float removed = samples.Dequeue();
+            accumulatedDuration -= removed;
+        }
+    }
+
+    private void LogSamples()
+    {
+        float min = float.MaxValue;
+        float max = float.MinValue;
+
+        foreach (float sample in samples)
+        {
+            if (sample < min)
+            {
+                min = sample;
+            }
+
+            if (sample > max)
+            {
+                max = sample;
+            }
+        }
+
+        float average = accumulatedDuration / samples.Count;
+        Debug.Log(
+            $"LOD benchmark for {name}: avg {average:F4} ms, min {min:F4} ms, max {max:F4} ms over {samples.Count} samples.",
+            this);
+    }
+
+    private void ResetLogTimer()
+    {
+        nextLogTime = Time.realtimeSinceStartup + Mathf.Max(0.001f, logIntervalSeconds);
+    }
+}

--- a/Assets/Scripts/Rendering/PlanetLodBenchmark.cs.meta
+++ b/Assets/Scripts/Rendering/PlanetLodBenchmark.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4d8b76a6ed94707a9bf4daea83cc367
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Rendering/PlanetLodController.cs
+++ b/Assets/Scripts/Rendering/PlanetLodController.cs
@@ -1,9 +1,26 @@
+using System;
+using System.Diagnostics;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "PlanetLodConfig", menuName = "Settings/Planet LOD Config")]
 public class PlanetLodConfig : ScriptableObject
 {
     public float[] transitionDistances = new float[] { 25f, 50f, 100f };
+
+    [Min(0f)]
+    public float updateInterval = 0.1f;
+
+    [Min(0f)]
+    public float transitionHysteresis = 5f;
+
+    public bool enableBenchmarking = false;
+
+    [Min(1)]
+    public int benchmarkSampleSize = 120;
+
+    [Min(0f)]
+    public float benchmarkLogInterval = 5f;
+
     public bool showDebugGizmos = false;
 }
 
@@ -16,9 +33,18 @@ public class PlanetLodController : MonoBehaviour
     [SerializeField]
     private PlanetLodConfig config;
 
-    private Mesh[] lodMeshes;
+    private Mesh[] lodMeshes = Array.Empty<Mesh>();
     private MeshFilter meshFilter;
+    private MeshCollider meshCollider;
     private Transform cameraTransform;
+    private bool isInitialized;
+    private int currentLodIndex;
+    private float nextLodUpdateTime;
+    private float[] degradeSqrThresholds = Array.Empty<float>();
+    private float[] upgradeSqrThresholds = Array.Empty<float>();
+    private readonly Stopwatch benchmarkStopwatch = new Stopwatch();
+
+    public event Action<float> LodEvaluated;
 
     /// <summary>
     /// Initializes the LOD controller with meshes and configuration.
@@ -27,36 +53,85 @@ public class PlanetLodController : MonoBehaviour
     /// <param name="lodConfig">Configuration for LOD distances and gizmos.</param>
     public void Initialize(Mesh[] meshes, PlanetLodConfig lodConfig)
     {
-        lodMeshes = meshes;
+        lodMeshes = meshes ?? Array.Empty<Mesh>();
         config = lodConfig;
-        meshFilter = GetComponent<MeshFilter>();
-        cameraTransform = Camera.main != null ? Camera.main.transform : null;
-
-        if (lodMeshes != null && lodMeshes.Length > 0)
+        meshFilter = meshFilter != null ? meshFilter : GetComponent<MeshFilter>();
+        if (meshFilter == null)
         {
-            meshFilter.mesh = lodMeshes[0];
+            UnityEngine.Debug.LogWarning("PlanetLodController requires a MeshFilter to operate.", this);
+            lodMeshes = Array.Empty<Mesh>();
+            isInitialized = false;
+            return;
+        }
+
+        cameraTransform = Camera.main != null ? Camera.main.transform : null;
+        currentLodIndex = 0;
+        isInitialized = lodMeshes.Length > 0;
+
+        if (isInitialized)
+        {
+            RebuildThresholds();
+            ApplyLod(currentLodIndex);
+        }
+
+        nextLodUpdateTime = Time.time;
+    }
+
+    public void SetMeshCollider(MeshCollider collider)
+    {
+        meshCollider = collider;
+        if (meshCollider != null && lodMeshes.Length > 0)
+        {
+            meshCollider.sharedMesh = lodMeshes[Mathf.Clamp(currentLodIndex, 0, lodMeshes.Length - 1)];
+        }
+    }
+
+    private void Awake()
+    {
+        meshFilter = GetComponent<MeshFilter>();
+        meshCollider = GetComponent<MeshCollider>();
+    }
+
+    private void OnEnable()
+    {
+        if (!isInitialized && lodMeshes.Length > 0 && meshFilter != null)
+        {
+            RebuildThresholds();
+            ApplyLod(Mathf.Clamp(currentLodIndex, 0, lodMeshes.Length - 1));
+            isInitialized = true;
         }
     }
 
     private void Update()
     {
-        if (lodMeshes == null || lodMeshes.Length == 0 || cameraTransform == null || config == null)
+        if (!isInitialized || lodMeshes.Length == 0 || meshFilter == null)
         {
             return;
         }
 
-        float distance = Vector3.Distance(transform.position, cameraTransform.position);
-        int level = 0;
-
-        for (int i = 0; i < config.transitionDistances.Length; i++)
+        if (cameraTransform == null)
         {
-            if (distance > config.transitionDistances[i])
+            Camera main = Camera.main;
+            if (main == null)
             {
-                level = Mathf.Min(i + 1, lodMeshes.Length - 1);
+                return;
             }
+
+            cameraTransform = main.transform;
         }
 
-        meshFilter.mesh = lodMeshes[level];
+        float updateInterval = config != null ? Mathf.Max(0f, config.updateInterval) : 0f;
+        float now = Time.time;
+        if (now < nextLodUpdateTime)
+        {
+            return;
+        }
+
+        nextLodUpdateTime = now + updateInterval;
+
+        Vector3 offset = cameraTransform.position - transform.position;
+        float sqrDistance = offset.sqrMagnitude;
+        EvaluateAndApplyLod(sqrDistance);
     }
 
     private void OnDrawGizmosSelected()
@@ -70,6 +145,116 @@ public class PlanetLodController : MonoBehaviour
         for (int i = 0; i < config.transitionDistances.Length; i++)
         {
             Gizmos.DrawWireSphere(transform.position, config.transitionDistances[i]);
+        }
+    }
+
+    private void EvaluateAndApplyLod(float sqrDistance)
+    {
+        bool benchmarking = LodEvaluated != null;
+        if (benchmarking)
+        {
+            benchmarkStopwatch.Restart();
+        }
+
+        int targetIndex = DetermineLodIndex(sqrDistance);
+        if (targetIndex != currentLodIndex)
+        {
+            ApplyLod(targetIndex);
+        }
+
+        if (benchmarking)
+        {
+            benchmarkStopwatch.Stop();
+            LodEvaluated?.Invoke((float)benchmarkStopwatch.Elapsed.TotalMilliseconds);
+        }
+    }
+
+    private int DetermineLodIndex(float sqrDistance)
+    {
+        int targetIndex = currentLodIndex;
+
+        for (int i = targetIndex; i < degradeSqrThresholds.Length; i++)
+        {
+            if (sqrDistance > degradeSqrThresholds[i])
+            {
+                targetIndex = i + 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        for (int i = targetIndex - 1; i >= 0; i--)
+        {
+            if (sqrDistance < upgradeSqrThresholds[i])
+            {
+                targetIndex = i;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return Mathf.Clamp(targetIndex, 0, lodMeshes.Length - 1);
+    }
+
+    private void ApplyLod(int targetIndex)
+    {
+        if (lodMeshes.Length == 0)
+        {
+            return;
+        }
+
+        currentLodIndex = Mathf.Clamp(targetIndex, 0, lodMeshes.Length - 1);
+        Mesh targetMesh = lodMeshes[currentLodIndex];
+        if (targetMesh == null)
+        {
+            return;
+        }
+
+        if (meshFilter.sharedMesh != targetMesh)
+        {
+            meshFilter.sharedMesh = targetMesh;
+        }
+
+        if (meshCollider != null && meshCollider.sharedMesh != targetMesh)
+        {
+            meshCollider.sharedMesh = targetMesh;
+        }
+    }
+
+    private void RebuildThresholds()
+    {
+        int transitions = Mathf.Max(0, lodMeshes.Length - 1);
+        if (transitions == 0)
+        {
+            degradeSqrThresholds = Array.Empty<float>();
+            upgradeSqrThresholds = Array.Empty<float>();
+            return;
+        }
+
+        float hysteresis = config != null ? Mathf.Max(0f, config.transitionHysteresis) : 0f;
+        degradeSqrThresholds = new float[transitions];
+        upgradeSqrThresholds = new float[transitions];
+
+        for (int i = 0; i < transitions; i++)
+        {
+            float distance = (config != null && i < config.transitionDistances.Length)
+                ? config.transitionDistances[i]
+                : float.PositiveInfinity;
+
+            if (float.IsPositiveInfinity(distance))
+            {
+                degradeSqrThresholds[i] = float.PositiveInfinity;
+                upgradeSqrThresholds[i] = float.PositiveInfinity;
+                continue;
+            }
+
+            degradeSqrThresholds[i] = distance * distance;
+            float upgradeDistance = Mathf.Max(0f, distance - hysteresis);
+            upgradeSqrThresholds[i] = upgradeDistance * upgradeDistance;
         }
     }
 }

--- a/Assets/Settings/PlanetLodConfig.asset
+++ b/Assets/Settings/PlanetLodConfig.asset
@@ -16,4 +16,9 @@ MonoBehaviour:
   - 25
   - 50
   - 100
+  updateInterval: 0.1
+  transitionHysteresis: 5
+  enableBenchmarking: 0
+  benchmarkSampleSize: 120
+  benchmarkLogInterval: 5
   showDebugGizmos: 0


### PR DESCRIPTION
## Summary
- add configurable update cadence, hysteresis, and benchmarking hooks to the planet LOD controller
- sync mesh colliders with active LOD meshes and optionally attach a runtime benchmark component
- extend the shared LOD configuration asset with tuning and benchmarking parameters

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cc18a5c90c8321ad1679798bd9703c